### PR TITLE
TST, CI: add 32-bit Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,3 +55,31 @@ jobs:
       cd testsuite
       pytest .\MDAnalysisTests --disable-pytest-warnings -n 2 -rsx
     displayName: 'Run MDAnalysis Test Suite'
+
+- job: Linux_Python_36_32bit
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - script: |
+           docker pull i386/ubuntu:bionic
+           docker run -v $(pwd):/mdanalysis i386/ubuntu:bionic /bin/bash -c "cd mdanalysis && \
+           apt-get -y update --fix-missing && \
+           apt-get -y install locales python3 python3-pip libfreetype6-dev && \
+           locale-gen en_US.UTF-8 && \
+           export LANG=en_US.UTF-8 && \
+           export LC_ALL=en_US.UTF-8 && \
+           python3 -m pip install --user --upgrade pip setuptools && \
+           python3 -m pip install --user --upgrade pytest pytest-xdist && \
+           python3 -m pip install --user --upgrade gsd cython numpy scipy hypothesis && \
+           cd /mdanalysis/package && \
+           python3 setup.py install --user && \
+           cd /mdanalysis/testsuite && \
+           python3 setup.py install --user && \
+           /root/.local/bin/pytest --disable-pytest-warnings --durations=50 ./MDAnalysisTests"
+    displayName: 'Run 32-bit Ubuntu Docker Build / Tests'
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: '**/test-*.xml'
+      failTaskOnFailedTests: true
+      testRunTitle: 'Publish test results for Python 3.6-32 bit Linux'

--- a/package/CHANGELOG
+++ b/package/CHANGELOG
@@ -99,7 +99,7 @@ Fixes
 
 Enhancements
   * Added support for FHI-AIMS input files (PR #2705)
-  * vastly improved support for 32-bit Windows (PR #2696)
+  * vastly improved support for 32-bit Linux and Windows (PR #2696)
   * Added methods to compute the root-mean-square-inner-product of subspaces 
     and the cumulative overlap of a vector in a subspace for PCA (PR #2613)
   * Added .frames and .times arrays to AnalysisBase (Issue #2661)


### PR DESCRIPTION
* add 32-bit Linux testing to Azure CI; Azure
has 10 parallel jobs and should still be far
faster than our Travis/Appveyor CI

* update `CHANGELOG` to reflect 32-bit Linux
support improvement