### PR TITLE
DEBUG, TST, CI: PEP518 test in CI (NumPy ABI compatibility)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,24 +26,43 @@ jobs:
         Python37-32bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x86'
+          BUILD_TYPE: 'normal'
         Python36-64bit-full:
           PYTHON_VERSION: '3.6'
           PYTHON_ARCH: 'x64'
+          BUILD_TYPE: 'normal'
         Python37-64bit-full:
           PYTHON_VERSION: '3.7'
           PYTHON_ARCH: 'x64'
+          BUILD_TYPE: 'normal'
         Python38-64bit-full:
           PYTHON_VERSION: '3.8'
           PYTHON_ARCH: 'x64'
+          BUILD_TYPE: 'normal'
         Python39-64bit-full:
           PYTHON_VERSION: '3.9'
           PYTHON_ARCH: 'x64'
+          BUILD_TYPE: 'normal'
+        Python38-64bit-full-wheel:
+          PYTHON_VERSION: '3.8'
+          PYTHON_ARCH: 'x64'
+          BUILD_TYPE: 'wheel'
   steps:
   - task: UsePythonVersion@0
     inputs:
       versionSpec: $(PYTHON_VERSION)
       addToPath: true
       architecture: $(PYTHON_ARCH)
+  # a PEP518 compliant wheel build shoud be
+  # able to build MDAnalysis in an isolated
+  # environment *before* any deps are installed
+  # "manually"
+  - powershell: |
+      cd package
+      python -m pip install .
+      cd ..
+    displayName: 'Build MDAnalysis (wheel)'
+    condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'wheel'))
   - script: python -m pip install --upgrade pip setuptools wheel
     displayName: 'Install tools'
   - script: >-
@@ -61,6 +80,14 @@ jobs:
       tqdm
       threadpoolctl
     displayName: 'Install dependencies'
+  # for wheel install testing, we pin to an
+  # older NumPy, the oldest version we support and that
+  # supports the Python version in use
+  # to check the ABI compatibility of our wheels
+  - script: >-
+      python -m pip install numpy==1.17.5
+    displayName: 'pin to older NumPy (wheel test)'
+    condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'wheel'))
   # TODO: recent rdkit is not on PyPI
   - script: >-
       python -m pip install
@@ -83,6 +110,7 @@ jobs:
       python setup.py install
       cd ..
     displayName: 'Build MDAnalysis'
+    condition: and(succeeded(), eq(variables['BUILD_TYPE'], 'normal'))
   - powershell: |
       cd testsuite
       pytest .\MDAnalysisTests --disable-pytest-warnings -n 2 -rsx --cov=MDAnalysis

--- a/package/pyproject.toml
+++ b/package/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+# Minimum requirements for the build system to execute
+requires = [
+    "Cython>=0.16",
+    "numpy>=1.16.0",
+    "setuptools",
+    "wheel",
+]


### PR DESCRIPTION
Test to see if NumPy ABI compatibility issue detected with PEP518 Azure CI wheel build test on my fork.