### PR TITLE
CI: native M1 testing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,15 @@
+macos_instance:
+  image: ghcr.io/cirruslabs/macos-monterey-base:latest
+
+task:
+  script: |
+    brew install python@3.10
+    brew install python-tk@3.10
+    /opt/homebrew/opt/python@3.10/bin/python3 -m venv ~/py_310
+    source ~/py_310/bin/activate
+    cd package
+    python -m pip install .
+    cd ../testsuite
+    python -m pip install .
+    python -m pip install pytest
+    python -m pytest MDAnalysisTests


### PR DESCRIPTION
* add native M1 MacOS testing to CI
with Cirrus CI:
https://cirrus-ci.org/guide/macOS/#macos-virtual-machines

* there is no concurrency so just a single
job/Python version for now
